### PR TITLE
Allowing for single command running of the CLI

### DIFF
--- a/admin/diderot_admin
+++ b/admin/diderot_admin
@@ -21,7 +21,7 @@ parent_dir = current_dir[:current_dir.rfind(os.path.sep)]
 
 sys.path.insert(0, parent_dir)
 
-from diderot_core import DiderotCLI
+from diderot_core import DiderotCLI, DiderotCLIArgumentGenerator
 import shlex
 
 
@@ -202,8 +202,10 @@ class DiderotAdminCLI(DiderotCLI):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) > 1:
-        # TODO: get rid of this ability from the student accessible version.
-        DiderotAdminCLI().cmdloop(sys.argv[1])
+    args = DiderotCLIArgumentGenerator.generate_args()
+    if args.command != None:
+        cli = DiderotAdminCLI(args.url, args.username, args.password, shouldPrintLoginMessage=False)
+        cli.initialize()
+        cli.onecmd(args.command)
     else:
-        DiderotAdminCLI().cmdloop("https://www.diderot.one")
+        DiderotAdminCLI(args.url, args.username, args.password).cmdloop()

--- a/api_calls.py
+++ b/api_calls.py
@@ -40,7 +40,7 @@ class DiderotAPIInterface:
                 sys.exit(0)
         self.csrftoken = self.client.cookies['csrftoken']
 
-    def login(self, username, password):
+    def login(self, username, password, shouldPrint=True):
         if self.logged_in:
             return True
         login_data = {'username' : username,
@@ -66,7 +66,8 @@ class DiderotAPIInterface:
                 self.logged_in = False
                 return False
         self.csrftoken = self.client.cookies['csrftoken']
-        print("Successfully logged in to Diderot.")
+        if shouldPrint:
+            print("Successfully logged in to Diderot.")
         self.logged_in = True
         return True
 

--- a/diderot
+++ b/diderot
@@ -7,11 +7,13 @@ Updated/Maintined by Rohan Yadav (rohany@alumni.cmu.edu)
 '''
 
 import sys
-from diderot_core import DiderotCLI
+from diderot_core import DiderotCLI, DiderotCLIArgumentGenerator
 
 if __name__ == '__main__':
-    if len(sys.argv) > 1:
-        # TODO: get rid of this ability from the student accessible version.
-        DiderotCLI().cmdloop(sys.argv[1])
+    args = DiderotCLIArgumentGenerator.generate_args()
+    if args.command != None:
+        cli = DiderotCLI(args.url, args.username, args.password, shouldPrintLoginMessage=False)
+        cli.initialize()
+        cli.onecmd(args.command)
     else:
-        DiderotCLI().cmdloop("https://www.diderot.one")
+        DiderotCLI(args.url, args.username, args.password).cmdloop()


### PR DESCRIPTION
This PR adds the --username, --password and --command flags to the CLI. When a command is passed to the --command flag, the CLI executes it and returns immediately, allowing for scripting behavior around the CLI.