### PR TITLE
 json upload refinements

### DIFF
--- a/api_calls.py
+++ b/api_calls.py
@@ -517,8 +517,9 @@ class DiderotAPIInterface:
                     base_path = Path(fg)
                     file_glob = glob.glob(self.expand_file_path(fg))
                     if not base_path.exists() and len(file_glob) == 0:
-                        print("Cannot find file {}. Exiting.".format(fg))
-                        return
+                        print("Warning: cannot find file {}. Skipping.".format(fg))
+                        
+                        continue
                     for g in file_glob:
                         f = Path(g).expanduser()
                         if f.is_dir():

--- a/api_calls.py
+++ b/api_calls.py
@@ -82,7 +82,7 @@ class DiderotAPIInterface:
         response = self.client.get(list_courses_url, headers=headers, params={'label': course_label})
         result = self.verify_singleton_response(response)
         if result is None:
-            print("The requested course label does not exist. You might not be a member of the requested course if it exists.")
+            print(f"The requested course label ({course_label}) does not exist. You might not be a member of the requested course if it exists.")
             return False
         return True
 

--- a/standalone.py
+++ b/standalone.py
@@ -228,6 +228,8 @@ class DiderotCLIArgs(object):
         upload_book = subparsers.add_parser(
             "upload_book", help="Perform bulk upload of book content.", formatter_class=Formatter)
         upload_book.add_argument(
+            "course", help="Course that the book belongs to.")
+        upload_book.add_argument(
             "upload_data", help="JSON upload details file.")
         return parser, subparsers
 
@@ -402,9 +404,11 @@ class DiderotAdmin(DiderotUser):
 
         # TODO (rohany): If the API of the api_client was better, we wouldn't
         #  need to do all of this various argument setting.
-        course_label = get_or_none(book_data, "course")
-        if course_label is None:
-            exit_with_error("invalid JSON: could not find field 'course'")
+        course_label = self.args.course
+
+        if not self.api_client.verify_course_label(course_label):
+            exit_with_error("Please specify a valid course for the book upload")
+
         book_label = get_or_none(book_data, "book")
         if book_label is None:
             exit_with_error("invalid JSON: could not find field 'book'")


### PR DESCRIPTION
This PR implements several refinements for json uploads.

Example command
```
diderot_admin --url https://community.diderot.one upload_book  "CMU:Pittsburgh, PA:15210:Community:2020" book.json
```
### Refinements
* if attachment not found simply skip with a warning
* require course label as an argument instead of being stored in json
