### PR TITLE
Update lab download link/error handling

### DIFF
--- a/api_calls.py
+++ b/api_calls.py
@@ -116,11 +116,18 @@ class DiderotAPIInterface:
     def download_assignment(self, course_label, homework_name):
         course = Course(self.client, course_label)
         lab = Lab(course, homework_name)
-        base_path = f"http://s3.amazonaws.com/diderot-codelabs-production/{course.label}/{lab.uuid}/"
-        writeup_path = base_path + "writeup.pdf"
-        handout_path = base_path + f"{lab.name}-handout.tgz"
-        for p in [writeup_path, handout_path]:
-            download_file_helper(p)
+        base_path = f"http://s3.amazonaws.com/codelabs-production/{course.label}/{lab.uuid}/"
+
+        files = {
+            'writeup': f"{base_path}writeup.pdf",
+            'handout': f"{base_path}{lab.name}-handout.tgz"
+        }
+
+        for kind, path in files.items():
+            try:
+                download_file_helper(path)
+            except APIError:
+                print(f"Could not find a {kind} for assignment {lab.name}")
 
     def update_assignment(self, course_label, homework_name, args):
         course = Course(self.client, course_label)

--- a/utils.py
+++ b/utils.py
@@ -41,10 +41,10 @@ def err_for_code(code):
 def download_file_helper(url):
     r = requests.get(url, stream=True)
     if r.status_code != 200:
-        return
+        raise APIError("Non 200 status code when downloading {}".format(url))
     local_filename = url.split("/")[-1]
     if os.path.isfile(local_filename):
-        raise APIError(
+        raise FileExistsError(
             "There is already a file called {}, so I won't download a new one."
             " Rename the old one and please try again".format(local_filename)
         )


### PR DESCRIPTION
I noticed lab downloads silently erroring out for 15-210 labs. It seems to me like the base_path should contain `codelabs-production` instead of `diderot-codelabs-production`, so I changed over the URL. If this isn't the case, feel free to edit.

Additionally, to avoid silent errors, I updated status code handling on `download_file_helper` and catch it in download_assignment in case no writeup exists.