### PR TITLE
Change command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ The student CLI contains basic commands to list, download, and submit assignment
 
 The CLI supports the following student commands.
 
-* `download-assignment`
-* `list-assignments`
-* `list-courses`
-* `submit-assignment`
+* `download_assignment`
+* `list_assignments`
+* `list_courses`
+* `submit_assignment`
 
 Please look at the Diderot Guide or use the CLI's help messages for more information about these commands.
 
@@ -56,22 +56,22 @@ The admin CLI contains all the commands of the student CLI along with commands t
 
 The CLI supports the following admin commands.
 
-* `create-book`
-* `create-chapter`
-* `create-part`
-* `download-assignment`
-* `list-assignments`
-* `list-books`
-* `list-chapters`
-* `list-courses`
-* `list-parts`
-* `publish-chapter`
-* `retract-chapter`
-* `set-publish-date`
-* `submit-assignment`
-* `update-assignment`
-* `upload-book`
-* `upload-chapter`
+* `create_book`
+* `create_chapter`
+* `create_part`
+* `download_assignment`
+* `list_assignments`
+* `list_books`
+* `list_chapters`
+* `list_courses`
+* `list_parts`
+* `publish_chapter`
+* `retract_chapter`
+* `set_publish_date`
+* `submit_assignment`
+* `update_assignment`
+* `upload_book`
+* `upload_chapter`
 
 Please look at the Diderot Guide or use the CLI's help messages for more information about these commands.
 

--- a/diderot_cli/commands/diderot_admin.py
+++ b/diderot_cli/commands/diderot_admin.py
@@ -10,7 +10,6 @@ from diderot_cli.context import DiderotContext, pass_diderot_context
 from diderot_cli.diderot_api import uses_api
 from diderot_cli.models import Book, Chapter, Course, Part
 from diderot_cli.utils import (
-    APIError,
     BookNotFoundAPIError,
     debug as debug_echo,
     exit_with_error,
@@ -141,7 +140,7 @@ def update_assignment(dc: DiderotContext, course: str, homework: str, **options)
 
 @click.command("upload_book")
 @args.course
-@click.argument("upload-data", type=click.Path(exists=True)) # Path? re-check this
+@click.argument("upload-data", type=click.Path(exists=True))  # Path? re-check this
 @opts.sleep_time
 @uses_api
 @pass_diderot_context
@@ -204,7 +203,7 @@ def upload_book(dc: DiderotContext, course: str, upload_data: str, **options):
     book_data_chapter_numbers = set([c.get("number") for c in book_data_chapters])
     actual_chapter_numbers = set([int(float(c["rank"])) for c in Chapter.list(course, book)])
     union_chapter_numbers = actual_chapter_numbers.union(book_data_chapter_numbers)
-    if union_chapter_numbers != set(range(1, len(union_chapter_numbers)+1)):
+    if union_chapter_numbers != set(range(1, len(union_chapter_numbers) + 1)):
         exit_with_error(f"invalid JSON: resulting chapters numbers are inconsistent, "
                         f"should be a sequence of integers starting with 1 including existing chapters. "
                         f"Current numbers set is: {actual_chapter_numbers} and resulting using json "
@@ -237,15 +236,12 @@ def upload_book(dc: DiderotContext, course: str, upload_data: str, **options):
 
         book = book_label
         part_num = get_or_none(chapter, "part")
-        chapter_number = number
-        chapter_label = label
-        pdf = adjust_search_path(get_or_none(chapter, "pdf"))
-        video_url = adjust_search_path(get_or_none(chapter, "video"))
-        xml = adjust_search_path(get_or_none(chapter, "xml"))
-        xml_pdf = adjust_search_path(get_or_none(chapter, "xml_pdf"))
+        # pdf = adjust_search_path(get_or_none(chapter, "pdf"))
+        # video_url = adjust_search_path(get_or_none(chapter, "video"))
+        # xml = adjust_search_path(get_or_none(chapter, "xml"))
+        # xml_pdf = adjust_search_path(get_or_none(chapter, "xml_pdf"))
         publish_date = get_or_none(chapter, "publish_on_date")
         publish_on_week = get_or_none(chapter, "publish_on_week")
-
 
         if number is None:
             exit_with_error(f"invalid JSON: must provide field 'number' for chapter {chapter}")

--- a/diderot_cli/commands/diderot_admin.py
+++ b/diderot_cli/commands/diderot_admin.py
@@ -18,6 +18,7 @@ from diderot_cli.utils import (
     print_list,
 )
 
+
 @click.group()
 @opts.api
 @opts.debug
@@ -34,7 +35,7 @@ def admin(dc: DiderotContext, **opts):
     debug_echo(f"Context object: {dc}")
 
 
-@click.command()
+@click.command("create_book")
 @args.multi_args(args.course, args.title, args.chapter_label)
 @uses_api
 @pass_diderot_context
@@ -42,7 +43,8 @@ def create_book(dc: DiderotContext, course: str, title: str, chapter_label: str)
     dc.client.create_book(course, title, chapter_label)
     click.echo("Successfully created book.")
 
-@click.command()
+
+@click.command("create_chapter")
 @args.multi_args(args.course, args.book)
 @opts.multi_opts(opts.part_number, opts.chapter_number, opts.chapter_label, opts.title)
 @uses_api
@@ -51,7 +53,8 @@ def create_chapter(dc: DiderotContext, course: str, book: str, **options):
     dc.client.create_chapter(course, book, **options)
     click.echo("Successfully created chapter.")
 
-@click.command()
+
+@click.command("create_part")
 @args.multi_args(args.course, args.book, args.title)
 @opts.multi_opts(opts.chapter_number, opts.chapter_label)
 @uses_api
@@ -60,7 +63,8 @@ def create_part(dc: DiderotContext, course: str, book: str, title: str, **option
     dc.client.create_part(course, book, title, **options)
     click.echo("Successfully created part.")
 
-@click.command()
+
+@click.command("list_books")
 @args.optional_course
 @click.option("--all", type=click.BOOL, default=False, is_flag=True)
 @uses_api
@@ -69,7 +73,8 @@ def list_books(dc: DiderotContext, course: str, all: bool):
     res = dc.client.list_books(course, all=all)
     print_list([c["label"] for c in res])
 
-@click.command()
+
+@click.command("list_chapters")
 @args.multi_args(args.course, args.book)
 @uses_api
 @pass_diderot_context
@@ -83,7 +88,8 @@ def list_chapters(dc: DiderotContext, course: str, book: str):
         ]
     )
 
-@click.command()
+
+@click.command("list_parts")
 @args.multi_args(args.course, args.book)
 @uses_api
 @pass_diderot_context
@@ -92,7 +98,8 @@ def list_parts(dc: DiderotContext, course: str, book: str):
     book = Book(course, book)
     print_list(["{}. {}".format(c["rank"], c["title"]) for c in Part.list(course, book)])
 
-@click.command()
+
+@click.command("publish_chapter")
 @args.multi_args(args.course, args.book)
 @opts.multi_opts(opts.chapter_number, opts.chapter_label)
 @uses_api
@@ -101,7 +108,8 @@ def publish_chapter(dc: DiderotContext, course: str, book: str, **options):
     dc.client.release_unrelease_chapter(course, book, release=True, **options)
     click.echo("Success publishing chapter.")
 
-@click.command()
+
+@click.command("set_publish_date")
 @args.multi_args(args.course, args.book)
 @opts.multi_opts(opts.chapter_number, opts.chapter_label, opts.publish_date, opts.publish_on_week)
 @uses_api
@@ -110,7 +118,8 @@ def set_publish_date(dc: DiderotContext, course: str, book: str, **options):
     dc.client.set_publish_date(course, book, **options)
     click.echo("Successfully set publish date for the chapter.")
 
-@click.command()
+
+@click.command("retract_chapter")
 @args.multi_args(args.course, args.book)
 @opts.multi_opts(opts.chapter_number, opts.chapter_label)
 @uses_api
@@ -119,7 +128,8 @@ def retract_chapter(dc: DiderotContext, course: str, book: str, **options):
     dc.client.release_unrelease_chapter(course, book, release=False, **options)
     click.echo("Success retracting chapter.")
 
-@click.command()
+
+@click.command("update_assignment")
 @args.multi_args(args.course, args.homework)
 @opts.multi_opts(opts.autograde_tar, opts.autograde_makefile, opts.handout)
 @uses_api
@@ -128,7 +138,8 @@ def update_assignment(dc: DiderotContext, course: str, homework: str, **options)
     dc.client.update_assignment(course, homework, **options)
     click.echo("Success uploading files.")
 
-@click.command()
+
+@click.command("upload_book")
 @args.course
 @click.argument("upload-data", type=click.Path(exists=True)) # Path? re-check this
 @opts.sleep_time
@@ -259,7 +270,8 @@ def upload_book(dc: DiderotContext, course: str, upload_data: str, **options):
         dc.client.upload_chapter(course.label, book.label, number, None, attach=attach, **options)
         click.echo("Successfully uploaded chapter.")
 
-@click.command()
+
+@click.command("upload_chapter")
 @args.multi_args(args.course, args.book)
 @opts.multi_opts(
     opts.chapter_number, opts.chapter_label,

--- a/diderot_cli/commands/diderot_user.py
+++ b/diderot_cli/commands/diderot_user.py
@@ -25,7 +25,7 @@ def student(dc: DiderotContext, **opts):
     debug_echo(f"Context object: {dc}")
 
 
-@click.command()
+@click.command("download_assignment")
 @args.multi_args(args.course, args.homework)
 @uses_api
 @pass_diderot_context
@@ -33,7 +33,8 @@ def download_assignment(dc: DiderotContext, course, homework):
     if dc.client.download_assignment(course, homework):
         click.echo("Successfully downloaded assignment.")
 
-@click.command()
+
+@click.command("list_assignments")
 @args.course
 @uses_api
 @pass_diderot_context
@@ -45,13 +46,15 @@ def list_assignments(dc: DiderotContext, course):
     else:
         print_list(labs)
 
-@click.command()
+
+@click.command("list_courses")
 @uses_api
 @pass_diderot_context
 def list_courses(dc: DiderotContext):
     print_list([c["label"] for c in Course.list(dc.client.client)])
 
-@click.command()
+
+@click.command("submit_assignment")
 @args.multi_args(args.course, args.homework, args.handin)
 @uses_api
 @pass_diderot_context

--- a/diderot_cli/commands/diderot_user.py
+++ b/diderot_cli/commands/diderot_user.py
@@ -3,11 +3,11 @@ import click
 import diderot_cli.arguments as args
 import diderot_cli.options as opts
 
-from diderot_cli.constants import DEFAULT_DIDEROT_URL
 from diderot_cli.context import DiderotContext, pass_diderot_context
 from diderot_cli.diderot_api import uses_api
 from diderot_cli.models import Course, Lab
 from diderot_cli.utils import print_list, debug as debug_echo
+
 
 @click.group()
 @opts.api

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(
     entry_points={
         "console_scripts": [
             "diderot = diderot_cli.commands:diderot",
+            "diderot_admin = diderot_cli.commands.diderot_admin:admin",
+            "diderot_student = diderot_cli.commands.diderot_user:student",
         ],
     },
 )

--- a/test.py
+++ b/test.py
@@ -48,7 +48,7 @@ class Base(unittest.TestCase):
 class TestDiderotUserCLI(Base):
     # TODO (rohany): add a test for credentials
     def test_list_courses(self):
-        self.run_user_cmd("list-courses")
+        self.run_user_cmd("list_courses")
         self.assert_successful_execution()
 
         # 6 extra elements in output for labels (splitted): "Active courses", "Inactive courses", "public courses"
@@ -59,14 +59,14 @@ class TestDiderotUserCLI(Base):
 
     def test_list_assignments(self):
         # Test invalid course label.
-        self.run_user_cmd("list-assignments fakelabel")
+        self.run_user_cmd("list_assignments fakelabel")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
         # Test that assignment data is correct when switching on course.
         for c in ["TestCourse0", "TestCourse1"]:
-            self.run_user_cmd(f"list-assignments {c}")
+            self.run_user_cmd(f"list_assignments {c}")
 
             self.assert_successful_execution()
 
@@ -77,46 +77,46 @@ class TestDiderotUserCLI(Base):
 
     def test_download_assignment(self):
         # Test invalid course label.
-        self.run_user_cmd("download-assignment fakelabel fakehw")
+        self.run_user_cmd("download_assignment fakelabel fakehw")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
         # Test invalid homework name.
-        self.run_user_cmd("download-assignment TestCourse0 fakehw")
+        self.run_user_cmd("download_assignment TestCourse0 fakehw")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Invalid homework name.")
 
         # Expect success with valid hw name and course name.
         with self.runner.isolated_filesystem():
-            self.run_user_cmd("download-assignment TestCourse0 TestHW1")
+            self.run_user_cmd("download_assignment TestCourse0 TestHW1")
 
         self.assert_successful_execution()
         self.assert_in_output("Successfully downloaded assignment.")
 
     def test_submit_assignment(self):
         # Test invalid course label.
-        self.run_user_cmd("submit-assignment fakelabel fakehw testdata/test_handin.tar")
+        self.run_user_cmd("submit_assignment fakelabel fakehw testdata/test_handin.tar")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
         self.assert_in_output("You might not be a member")
 
         # Test invalid homework name.
-        self.run_user_cmd("submit-assignment TestCourse0 fakehw testdata/test_handin.tar")
+        self.run_user_cmd("submit_assignment TestCourse0 fakehw testdata/test_handin.tar")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Invalid homework name.")
 
         # Test invalid input file name.
-        self.run_user_cmd("submit-assignment TestCourse0 TestHW1 testdata/invalid.tar")
+        self.run_user_cmd("submit_assignment TestCourse0 TestHW1 testdata/invalid.tar")
 
         self.assert_unsuccessful_execution(exit_code=2)
         self.assert_in_output("Path 'testdata/invalid.tar' does not exist.")
 
         # Expect successful execution here!
-        self.run_user_cmd("submit-assignment TestCourse0 TestHW1 testdata/test_handin.tar")
+        self.run_user_cmd("submit_assignment TestCourse0 TestHW1 testdata/test_handin.tar")
 
         self.assert_successful_execution()
         self.assert_in_output("Assignment submitted successfully.")
@@ -125,90 +125,90 @@ class TestDiderotUserCLI(Base):
 class TestDiderotAdminCLI(Base):
     def test_create_chapter(self):
         # Test invalid course label.
-        self.run_admin_cmd("create-chapter fakecourse fakebook --chapter-number 1")
+        self.run_admin_cmd("create_chapter fakecourse fakebook --chapter-number 1")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
         # Test invalid book label.
-        self.run_admin_cmd("create-chapter TestCourse0 fakebook --chapter-number 1")
+        self.run_admin_cmd("create_chapter TestCourse0 fakebook --chapter-number 1")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input book not found.")
 
         # Test error is raised when book is not a booklet and parts is not provided.
-        self.run_admin_cmd("create-chapter TestCourse0 TestBook1 --chapter-number 1")
+        self.run_admin_cmd("create_chapter TestCourse0 TestBook1 --chapter-number 1")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("--part-number must be set.")
 
         # Test error when input part is invalid.
-        self.run_admin_cmd("create-chapter TestCourse0 TestBook1 --part-number 3 --chapter-number 1")
+        self.run_admin_cmd("create_chapter TestCourse0 TestBook1 --part-number 3 --chapter-number 1")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input part not found.")
 
         # Test error when chapter exists.
-        self.run_admin_cmd("create-chapter TestCourse0 TestBook1 --part-number 1 --chapter-number 1")
+        self.run_admin_cmd("create_chapter TestCourse0 TestBook1 --part-number 1 --chapter-number 1")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Existing chapter for")
 
         # Expect a successful response.
         self.run_admin_cmd(
-            "create-chapter TestCourse0 TestBook1 --part-number 1 --chapter-number 3 --title TestChapter3 --chapter-label TestChapter3"
+            "create_chapter TestCourse0 TestBook1 --part-number 1 --chapter-number 3 --title TestChapter3 --chapter-label TestChapter3"
         )
         self.assert_successful_execution()
         self.assert_in_output("Successfully created chapter.")
 
         # Expect successful response for non booklets.
         self.run_admin_cmd(
-            "create-chapter TestCourse0 TestBook2 --part-number 1 --chapter-number 3 --title TestChapter3 --chapter-label TestChapter3"
+            "create_chapter TestCourse0 TestBook2 --part-number 1 --chapter-number 3 --title TestChapter3 --chapter-label TestChapter3"
         )
         self.assert_successful_execution()
         self.assert_in_output("Successfully created chapter.")
 
     def test_create_part(self):
         # Test an invalid course label.
-        self.run_admin_cmd("create-part fakecourse fakebook NewTestPart --chapter-number 1")
+        self.run_admin_cmd("create_part fakecourse fakebook NewTestPart --chapter-number 1")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
         # Test an invalid book label.
-        self.run_admin_cmd("create-part TestCourse0 fakebook NewTestPart --chapter-number 1")
+        self.run_admin_cmd("create_part TestCourse0 fakebook NewTestPart --chapter-number 1")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input book not found.")
 
         # Test error when part exists.
-        self.run_admin_cmd("create-part TestCourse0 TestBook1 NewTestPart --chapter-number 1")
+        self.run_admin_cmd("create_part TestCourse0 TestBook1 NewTestPart --chapter-number 1")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Existing part for Course")
 
         # Expect successful response.
-        self.run_admin_cmd("create-part TestCourse0 TestBook1 NewTestPart --chapter-number 3 --chapter-label NewTestPart")
+        self.run_admin_cmd("create_part TestCourse0 TestBook1 NewTestPart --chapter-number 3 --chapter-label NewTestPart")
 
         self.assert_successful_execution()
         self.assert_in_output("Successfully created part.")
 
     def test_list_books(self):
         # With no course provided, expect an error.
-        self.run_admin_cmd("list-books")
+        self.run_admin_cmd("list_books")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("A course label is required if not listing all books.")
 
         # Test with invalid course label.
-        self.run_admin_cmd("list-books fakecourse")
+        self.run_admin_cmd("list_books fakecourse")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
         # Test with a valid input course label.
         for c in ["TestCourse0", "TestCourse1"]:
-            self.run_admin_cmd("list-books {}".format(c))
+            self.run_admin_cmd("list_books {}".format(c))
 
             self.assert_successful_execution()
 
@@ -218,7 +218,7 @@ class TestDiderotAdminCLI(Base):
                 self.assert_in_output(b["label"])
 
         # Test the --all flag.
-        self.run_admin_cmd("list-books --all")
+        self.run_admin_cmd("list_books --all")
 
         self.assert_successful_execution()
         self.assertTrue(len(shlex.split(self.result.output)) == len(books))
@@ -228,19 +228,19 @@ class TestDiderotAdminCLI(Base):
 
     def test_list_chapters(self):
         # Test invalid course label.
-        self.run_admin_cmd("list-chapters fakecourse fakebook")
+        self.run_admin_cmd("list_chapters fakecourse fakebook")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
         # Test invalid book label.
-        self.run_admin_cmd("list-chapters TestCourse0 fakebook")
+        self.run_admin_cmd("list_chapters TestCourse0 fakebook")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input book not found.")
 
         # Test that we get expected results with a valid book.
-        self.run_admin_cmd("list-chapters TestCourse0 TestBook1")
+        self.run_admin_cmd("list_chapters TestCourse0 TestBook1")
 
         self.assert_successful_execution()
 
@@ -251,26 +251,26 @@ class TestDiderotAdminCLI(Base):
             self.assert_in_output(s)
 
         # Test that we don't get any results with a book with no chapters.
-        self.run_admin_cmd("list-chapters TestCourse0 TestBook2")
+        self.run_admin_cmd("list_chapters TestCourse0 TestBook2")
 
         self.assert_successful_execution()
         self.assertTrue(len(self.result.output) == 0)
 
     def test_list_parts(self):
         # Test invalid course label.
-        self.run_admin_cmd("list-parts fakecourse fakebook")
+        self.run_admin_cmd("list_parts fakecourse fakebook")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
         # Test invalid book label.
-        self.run_admin_cmd("list-parts TestCourse0 fakebook")
+        self.run_admin_cmd("list_parts TestCourse0 fakebook")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input book not found.")
 
         # Test that we get expected results with a valid book.
-        self.run_admin_cmd("list-parts TestCourse0 TestBook1")
+        self.run_admin_cmd("list_parts TestCourse0 TestBook1")
 
         self.assert_successful_execution()
 
@@ -282,93 +282,93 @@ class TestDiderotAdminCLI(Base):
             self.assert_in_output(s)
 
         # Test that we don't get any results with a book with no parts.
-        self.run_admin_cmd("list-parts TestCourse1 TestBook3")
+        self.run_admin_cmd("list_parts TestCourse1 TestBook3")
 
         self.assert_successful_execution()
         self.assertTrue(len(self.result.output) == 0)
 
     def test_publish_retract_chapter(self):
         # Test invalid course label.
-        self.run_admin_cmd("publish-chapter fakecourse fakebook --chapter-number 10")
+        self.run_admin_cmd("publish_chapter fakecourse fakebook --chapter-number 10")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
-        self.run_admin_cmd("retract-chapter fakecourse fakebook --chapter-number 10")
+        self.run_admin_cmd("retract_chapter fakecourse fakebook --chapter-number 10")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
         # Test invalid book.
-        self.run_admin_cmd("publish-chapter TestCourse0 fakebook --chapter-number 10")
+        self.run_admin_cmd("publish_chapter TestCourse0 fakebook --chapter-number 10")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input book not found.")
 
-        self.run_admin_cmd("retract-chapter TestCourse0 fakebook --chapter-number 10")
+        self.run_admin_cmd("retract_chapter TestCourse0 fakebook --chapter-number 10")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input book not found.")
 
         # Test invalid chapter number.
-        self.run_admin_cmd("publish-chapter TestCourse0 TestBook1 --chapter-number 10")
+        self.run_admin_cmd("publish_chapter TestCourse0 TestBook1 --chapter-number 10")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input chapter not found.")
 
-        self.run_admin_cmd("retract-chapter TestCourse0 TestBook1 --chapter-number 10")
+        self.run_admin_cmd("retract_chapter TestCourse0 TestBook1 --chapter-number 10")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input chapter not found.")
 
         # Test invalid chapter label.
-        self.run_admin_cmd("publish-chapter TestCourse0 TestBook1 --chapter-label fakelabel")
+        self.run_admin_cmd("publish_chapter TestCourse0 TestBook1 --chapter-label fakelabel")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input chapter not found.")
 
-        self.run_admin_cmd("retract-chapter TestCourse0 TestBook1 --chapter-label fakelabel")
+        self.run_admin_cmd("retract_chapter TestCourse0 TestBook1 --chapter-label fakelabel")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input chapter not found.")
 
         # Test success in releasing chapter.
-        self.run_admin_cmd("publish-chapter TestCourse0 TestBook1 --chapter-label TestChapter1")
+        self.run_admin_cmd("publish_chapter TestCourse0 TestBook1 --chapter-label TestChapter1")
 
         self.assert_successful_execution()
         self.assert_in_output("Success publishing chapter.")
 
-        self.run_admin_cmd("retract-chapter TestCourse0 TestBook1 --chapter-label TestChapter1")
+        self.run_admin_cmd("retract_chapter TestCourse0 TestBook1 --chapter-label TestChapter1")
 
         self.assert_successful_execution()
         self.assert_in_output("Success retracting chapter.")
 
-        self.run_admin_cmd("publish-chapter TestCourse0 TestBook1 --chapter-number 1")
+        self.run_admin_cmd("publish_chapter TestCourse0 TestBook1 --chapter-number 1")
 
         self.assert_successful_execution()
         self.assert_in_output("Success publishing chapter.")
 
-        self.run_admin_cmd("retract-chapter TestCourse0 TestBook1 --chapter-number 1")
+        self.run_admin_cmd("retract_chapter TestCourse0 TestBook1 --chapter-number 1")
 
         self.assert_successful_execution()
         self.assert_in_output("Success retracting chapter.")
 
     def test_update_assignment(self):
         # Test invalid course label.
-        self.run_admin_cmd("update-assignment fakecourse fakehw")
+        self.run_admin_cmd("update_assignment fakecourse fakehw")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
         # Test invalid homework name.
-        self.run_admin_cmd("update-assignment TestCourse0 fakehw")
+        self.run_admin_cmd("update_assignment TestCourse0 fakehw")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Invalid homework name.")
 
         # Expect success.
         self.run_admin_cmd(
-            "update-assignment TestCourse0 TestHW1 --autograde-tar testdata/autograde.tar\
+            "update_assignment TestCourse0 TestHW1 --autograde-tar testdata/autograde.tar\
              --autograde-makefile testdata/autograde-Makefile \
              --handout testdata/handout.tar"
         )
@@ -377,25 +377,25 @@ class TestDiderotAdminCLI(Base):
 
     def test_upload_chapter(self):
         # Test invalid course label.
-        self.run_admin_cmd("upload-chapter fakecourse fakebook --chapter-number 10 --pdf testdata/chapter.pdf")
+        self.run_admin_cmd("upload_chapter fakecourse fakebook --chapter-number 10 --pdf testdata/chapter.pdf")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
         # Test invalid book.
-        self.run_admin_cmd("upload-chapter TestCourse0 fakebook --chapter-number 10 --pdf testdata/chapter.pdf")
+        self.run_admin_cmd("upload_chapter TestCourse0 fakebook --chapter-number 10 --pdf testdata/chapter.pdf")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input book not found.")
 
         # Test invalid chapter number.
-        self.run_admin_cmd("upload-chapter TestCourse0 TestBook1 --chapter-number 10 --pdf testdata/chapter.pdf")
+        self.run_admin_cmd("upload_chapter TestCourse0 TestBook1 --chapter-number 10 --pdf testdata/chapter.pdf")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input chapter not found.")
 
         # Test invalid chapter label.
-        self.run_admin_cmd("upload-chapter TestCourse0 TestBook1 --chapter-label fakelabel --pdf testdata/chapter.pdf")
+        self.run_admin_cmd("upload_chapter TestCourse0 TestBook1 --chapter-label fakelabel --pdf testdata/chapter.pdf")
 
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input chapter not found.")
@@ -403,44 +403,44 @@ class TestDiderotAdminCLI(Base):
         # Pdf upload test.
         # Expect an error if used not on a pdf.
         self.run_admin_cmd(
-            "upload-chapter TestCourse0 TestBook1 --chapter-number 1 --pdf testdata/book.xml --video-url fakeurl"
+            "upload_chapter TestCourse0 TestBook1 --chapter-number 1 --pdf testdata/book.xml --video-url fakeurl"
         )
         self.assert_in_output("PDF argument must be a PDF file.")
 
         self.run_admin_cmd(
-            "upload-chapter TestCourse0 TestBook1 --chapter-number 1 --pdf testdata/chapter.pdf --video-url fakeurl"
+            "upload_chapter TestCourse0 TestBook1 --chapter-number 1 --pdf testdata/chapter.pdf --video-url fakeurl"
         )
         self.assert_successful_execution()
         self.assert_in_output("Chapter uploaded successfully.")
 
         # Xml/mlx upload test.
         self.run_admin_cmd(
-            "upload-chapter TestCourse0 TestBook1 --chapter-number 1 --xml testdata/book.xml --xml-pdf testdata/book.pdf"
+            "upload_chapter TestCourse0 TestBook1 --chapter-number 1 --xml testdata/book.xml --xml-pdf testdata/book.pdf"
         )
         self.assert_successful_execution()
         self.assert_in_output("Chapter uploaded successfully.")
 
         self.run_admin_cmd(
-            "upload-chapter TestCourse0 TestBook1 --chapter-label TestChapter1 --xml testdata/book.xml --xml-pdf testdata/book.pdf"
+            "upload_chapter TestCourse0 TestBook1 --chapter-label TestChapter1 --xml testdata/book.xml --xml-pdf testdata/book.pdf"
         )
         self.assert_successful_execution()
         self.assert_in_output("Chapter uploaded successfully.")
 
         self.run_admin_cmd(
-            "upload-chapter TestCourse0 TestBook1 --chapter-number 1 --xml testdata/book.mlx --xml-pdf testdata/book.pdf"
+            "upload_chapter TestCourse0 TestBook1 --chapter-number 1 --xml testdata/book.mlx --xml-pdf testdata/book.pdf"
         )
         self.assert_successful_execution()
         self.assert_in_output("Chapter uploaded successfully.")
 
         self.run_admin_cmd(
-            "upload-chapter TestCourse0 TestBook1 --chapter-label TestChapter1 --xml testdata/book.mlx --xml-pdf testdata/book.pdf"
+            "upload_chapter TestCourse0 TestBook1 --chapter-label TestChapter1 --xml testdata/book.mlx --xml-pdf testdata/book.pdf"
         )
         self.assert_successful_execution()
         self.assert_in_output("Chapter uploaded successfully.")
 
         # Test folder.
         self.run_admin_cmd(
-            "upload-chapter TestCourse0 TestBook1 --chapter-number 1 --xml testdata/book.mlx --xml-pdf testdata/book.pdf --attach testdata/images/"
+            "upload_chapter TestCourse0 TestBook1 --chapter-number 1 --xml testdata/book.mlx --xml-pdf testdata/book.pdf --attach testdata/images/"
         )
         self.assert_successful_execution()
         self.assert_in_output("Uploading file: test1.png")
@@ -449,7 +449,7 @@ class TestDiderotAdminCLI(Base):
 
         # Test file list.
         self.run_admin_cmd(
-            "upload-chapter TestCourse0 TestBook1 --chapter-number 1 --xml testdata/book.mlx --xml-pdf testdata/book.pdf --attach testdata/images/test1.png --attach testdata/images/test2.png"
+            "upload_chapter TestCourse0 TestBook1 --chapter-number 1 --xml testdata/book.mlx --xml-pdf testdata/book.pdf --attach testdata/images/test1.png --attach testdata/images/test2.png"
         )
         self.assert_successful_execution()
         self.assert_in_output("Uploading file: test1.png")
@@ -459,40 +459,40 @@ class TestDiderotAdminCLI(Base):
     def test_set_publish_date_for_chapter(self):
         # Test invalid course label.
         self.run_admin_cmd(
-            "set-publish-date fakecourse fakebook --chapter-number 10 --publish-date \"2021-06-10T10:15\""
+            "set_publish_date fakecourse fakebook --chapter-number 10 --publish-date \"2021-06-10T10:15\""
         )
         self.assert_unsuccessful_execution()
         self.assert_in_output("The requested course label does not exist.")
 
         # Test invalid book.
         self.run_admin_cmd(
-            "set-publish-date TestCourse0 fakebook --chapter-number 10 --publish-date \"2021-06-10T10:15\""
+            "set_publish_date TestCourse0 fakebook --chapter-number 10 --publish-date \"2021-06-10T10:15\""
         )
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input book not found.")
 
         # Test invalid chapter number.
         self.run_admin_cmd(
-            "set-publish-date TestCourse0 TestBook1 --chapter-number 10 --publish-date \"2021-06-10T10:15\""
+            "set_publish_date TestCourse0 TestBook1 --chapter-number 10 --publish-date \"2021-06-10T10:15\""
         )
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input chapter not found.")
 
         # Test invalid chapter label.
         self.run_admin_cmd(
-            "set-publish-date TestCourse0 TestBook1 --chapter-label fakelabel --publish-date \"2021-06-10T10:15\""
+            "set_publish_date TestCourse0 TestBook1 --chapter-label fakelabel --publish-date \"2021-06-10T10:15\""
         )
         self.assert_unsuccessful_execution()
         self.assert_in_output("Input chapter not found.")
 
         # Test success in setting date for chapter.
         self.run_admin_cmd(
-            "set-publish-date TestCourse0 TestBook1 --chapter-label TestChapter1 --publish-date \"2021-06-10T10:15\""
+            "set_publish_date TestCourse0 TestBook1 --chapter-label TestChapter1 --publish-date \"2021-06-10T10:15\""
         )
         self.assert_in_output("Successfully set publish date for the chapter.")
 
         self.run_admin_cmd(
-            "set-publish-date TestCourse0 TestBook1 --chapter-number 1 --publish-on-week \"3/5, 14:30\""
+            "set_publish_date TestCourse0 TestBook1 --chapter-number 1 --publish-on-week \"3/5, 14:30\""
         )
         self.assert_in_output("Successfully set publish date for the chapter.")
 


### PR DESCRIPTION
- Added explicit command names (to prevent converting underscores to dashes)
- Added aliases `diderot_admin` and `diderot_student` for `diderot admin` and `diderot student` commands
- Small refactoring
***
Related issue: https://github.com/diderot-edu/diderot-dashboard/issues/798