### PR TITLE
explicit aliases for student commands

### DIFF
--- a/diderot_cli/commands/diderot_admin.py
+++ b/diderot_cli/commands/diderot_admin.py
@@ -314,9 +314,13 @@ def register_commands(click_group: click.Group):
         upload_book,
         upload_chapter,
         diderot_user.download_assignment,
+        diderot_user.download_assignment_,
         diderot_user.list_assignments,
+        diderot_user.list_assignments_,
         diderot_user.list_courses,
+        diderot_user.list_courses_,
         diderot_user.submit_assignment,
+        diderot_user.submit_assignment_,
     ]
 
     for c in commands:

--- a/diderot_cli/commands/diderot_user.py
+++ b/diderot_cli/commands/diderot_user.py
@@ -25,14 +25,6 @@ def student(dc: DiderotContext, **opts):
     debug_echo(f"Context object: {dc}")
 
 
-@click.command("download_assignment")
-@args.multi_args(args.course, args.homework)
-@uses_api
-@pass_diderot_context
-def download_assignment_(dc: DiderotContext, course, homework):
-    if dc.client.download_assignment(course, homework):
-        click.echo("Successfully downloaded assignment.")
-
 @click.command("download-assignment")
 @args.multi_args(args.course, args.homework)
 @uses_api
@@ -41,18 +33,13 @@ def download_assignment(dc: DiderotContext, course, homework):
     if dc.client.download_assignment(course, homework):
         click.echo("Successfully downloaded assignment.")
 
-
-@click.command("list_assignments")
-@args.course
+@click.command("download_assignment")
+@args.multi_args(args.course, args.homework)
 @uses_api
 @pass_diderot_context
-def list_assignments_(dc: DiderotContext, course):
-    course = Course(dc.client.client, course)
-    labs = [hw["name"] for hw in Lab.list(course)]
-    if len(labs) == 0:
-        click.echo("Course has no labs.")
-    else:
-        print_list(labs)
+def download_assignment_(dc: DiderotContext, course, homework):
+    if dc.client.download_assignment(course, homework):
+        click.echo("Successfully downloaded assignment.")
 
 @click.command("list-assignments")
 @args.course
@@ -66,12 +53,17 @@ def list_assignments(dc: DiderotContext, course):
     else:
         print_list(labs)
 
-
-@click.command("list_courses_")
+@click.command("list_assignments")
+@args.course
 @uses_api
 @pass_diderot_context
-def list_courses(dc: DiderotContext):
-    print_list([c["label"] for c in Course.list(dc.client.client)])
+def list_assignments_(dc: DiderotContext, course):
+    course = Course(dc.client.client, course)
+    labs = [hw["name"] for hw in Lab.list(course)]
+    if len(labs) == 0:
+        click.echo("Course has no labs.")
+    else:
+        print_list(labs)
 
 @click.command("list-courses")
 @uses_api
@@ -79,14 +71,12 @@ def list_courses(dc: DiderotContext):
 def list_courses(dc: DiderotContext):
     print_list([c["label"] for c in Course.list(dc.client.client)])
 
-
-@click.command("submit_assignment_")
-@args.multi_args(args.course, args.homework, args.handin)
+@click.command("list_courses")
 @uses_api
 @pass_diderot_context
-def submit_assignment(dc: DiderotContext, course: str, homework: str, handin: str):
-    dc.client.submit_assignment(course, homework, handin)
-    click.echo("Assignment submitted successfully. Track your submission's status on Diderot.")
+def list_courses_(dc: DiderotContext):
+    print_list([c["label"] for c in Course.list(dc.client.client)])
+
 
 @click.command("submit-assignment")
 @args.multi_args(args.course, args.homework, args.handin)
@@ -96,6 +86,13 @@ def submit_assignment(dc: DiderotContext, course: str, homework: str, handin: st
     dc.client.submit_assignment(course, homework, handin)
     click.echo("Assignment submitted successfully. Track your submission's status on Diderot.")
 
+@click.command("submit_assignment")
+@args.multi_args(args.course, args.homework, args.handin)
+@uses_api
+@pass_diderot_context
+def submit_assignment_(dc: DiderotContext, course: str, homework: str, handin: str):
+    dc.client.submit_assignment(course, homework, handin)
+    click.echo("Assignment submitted successfully. Track your submission's status on Diderot.")
 
 def register_commands(click_group: click.Group):
     commands = [

--- a/diderot_cli/commands/diderot_user.py
+++ b/diderot_cli/commands/diderot_user.py
@@ -3,14 +3,13 @@ import click
 import diderot_cli.arguments as args
 import diderot_cli.options as opts
 
-from click_aliases import ClickAliasedGroup
 from diderot_cli.context import DiderotContext, pass_diderot_context
 from diderot_cli.diderot_api import uses_api
 from diderot_cli.models import Course, Lab
 from diderot_cli.utils import print_list, debug as debug_echo
 
 
-@click.group(cls=ClickAliasedGroup)
+@click.group()
 @opts.api
 @opts.debug
 @pass_diderot_context
@@ -26,7 +25,15 @@ def student(dc: DiderotContext, **opts):
     debug_echo(f"Context object: {dc}")
 
 
-@student.command(aliases=["download_assignment", "download-assignment"])
+@click.command("download_assignment")
+@args.multi_args(args.course, args.homework)
+@uses_api
+@pass_diderot_context
+def download_assignment_(dc: DiderotContext, course, homework):
+    if dc.client.download_assignment(course, homework):
+        click.echo("Successfully downloaded assignment.")
+
+@click.command("download-assignment")
 @args.multi_args(args.course, args.homework)
 @uses_api
 @pass_diderot_context
@@ -35,7 +42,19 @@ def download_assignment(dc: DiderotContext, course, homework):
         click.echo("Successfully downloaded assignment.")
 
 
-@student.command(aliases=["list_assignments", "list-assignments"])
+@click.command("list_assignments")
+@args.course
+@uses_api
+@pass_diderot_context
+def list_assignments_(dc: DiderotContext, course):
+    course = Course(dc.client.client, course)
+    labs = [hw["name"] for hw in Lab.list(course)]
+    if len(labs) == 0:
+        click.echo("Course has no labs.")
+    else:
+        print_list(labs)
+
+@click.command("list-assignments")
 @args.course
 @uses_api
 @pass_diderot_context
@@ -48,14 +67,28 @@ def list_assignments(dc: DiderotContext, course):
         print_list(labs)
 
 
-@student.command(aliases=["list_courses", "list-courses"])
+@click.command("list_courses_")
+@uses_api
+@pass_diderot_context
+def list_courses(dc: DiderotContext):
+    print_list([c["label"] for c in Course.list(dc.client.client)])
+
+@click.command("list-courses")
 @uses_api
 @pass_diderot_context
 def list_courses(dc: DiderotContext):
     print_list([c["label"] for c in Course.list(dc.client.client)])
 
 
-@student.command(aliases=["submit_assignment", "submit-assignments"])
+@click.command("submit_assignment_")
+@args.multi_args(args.course, args.homework, args.handin)
+@uses_api
+@pass_diderot_context
+def submit_assignment(dc: DiderotContext, course: str, homework: str, handin: str):
+    dc.client.submit_assignment(course, homework, handin)
+    click.echo("Assignment submitted successfully. Track your submission's status on Diderot.")
+
+@click.command("submit-assignment")
 @args.multi_args(args.course, args.homework, args.handin)
 @uses_api
 @pass_diderot_context
@@ -67,9 +100,13 @@ def submit_assignment(dc: DiderotContext, course: str, homework: str, handin: st
 def register_commands(click_group: click.Group):
     commands = [
         download_assignment,
+        download_assignment_,
         list_assignments,
+        list_assignments_,
         list_courses,
+        list_courses_,
         submit_assignment,
+        submit_assignment_,
     ]
 
     for c in commands:


### PR DESCRIPTION
use explicit aliases for student commands so that they can be used by both the "admin" and the "student" modes